### PR TITLE
plot_histogram

### DIFF
--- a/imgui/__init__.pyi
+++ b/imgui/__init__.pyi
@@ -1,5 +1,5 @@
-import sys
 import typing as t
+from array import array
 from typing import Any
 
 Vec2 = tuple[float, float]
@@ -1161,6 +1161,17 @@ def plot_lines(
     # low-level
     values_count: int = -1,
     values_offset: int = 0,
+    stride: int = ...,
+): ...
+def plot_histogram(
+    label: str,
+    values: array[float] | Any,  # https://github.com/cython/cython/issues/6272
+    values_count: int = -1,
+    values_offset: int = 0,
+    overlay_text: str | None = None,
+    scale_min: float = FLOAT_MAX,
+    scale_max: float = FLOAT_MAX,
+    graph_size: tuple[float, float] = (0, 0),
     stride: int = ...,
 ): ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyimgui-stubs"
-version = "0.0.2"
+version = "0.0.3"
 description = "stub files for pyimgui package"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -12,4 +12,3 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/denballakh/pyimgui-stubs"
 Issues = "https://github.com/denballakh/pyimgui-stubs/issues"
-


### PR DESCRIPTION
https://pyimgui.readthedocs.io/en/latest/reference/imgui.core.html#imgui.core.plot_histogram

> ### Parameters:
> - label (str) – A plot label that will be displayed on the plot’s right side. If you want the label to be invisible, add "##" before the label’s text: "my_label" -> "##my_label"
> - values (array of floats) – the y-values. It must be a type that supports Cython’s Memoryviews, (See: http://docs.cython.org/en/latest/src/userguide/memoryviews.html) for example a numpy array.
> - overlay_text (str or None, optional) – Overlay text.
> - scale_min (float, optional) – y-value at the bottom of the plot.
> - scale_max (float, optional) – y-value at the top of the plot.
> - graph_size (tuple of two floats, optional) – plot size in pixels. Note: In ImGui 1.49, (-1,-1) will NOT auto-size the plot. To do that, use get_content_region_available() and pass in the right size.

> Note: These low-level parameters are exposed if needed for performance:
> 
> - values_offset (int): Index of first element to display
> - values_count (int): Number of values to display. -1 will use the entire array.
> - stride (int): Number of bytes to move to read next element.


Wraps API:

```cpp
void PlotHistogram(
    const char* label, const float* values, int values_count,
    # note: optional
    int values_offset,
    const char* overlay_text,
    float scale_min,
    float scale_max,
    ImVec2 graph_size,
    int stride
)
```