### PR TITLE
`[build-system]` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ classifiers = [
 Homepage = "https://github.com/denballakh/pyimgui-stubs"
 Issues = "https://github.com/denballakh/pyimgui-stubs/issues"
 
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adds a `[build-system]` table and uses standard `setuptools` as a backend.

See https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-build-system-dependencies-the-build-system-table

This way, the wheel can be built using [`uv build`](https://docs.astral.sh/uv/concepts/projects/build/#using-uv-build)